### PR TITLE
Ensure your security group rule blocks unwanted inbound traffic

### DIFF
--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -32,14 +32,12 @@ resource "aws_security_group" "tfgoat-cluster" {
   name        = "${local.prefix}-tfgoat-cluster"
   description = "Cluster communication with worker nodes"
   vpc_id      = aws_vpc.tfgoat.id
-
   ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
+    protocol = "<set as you like (e.g. tcp)>"
+    from_port = 1337 # TODO: set as you like
+    to_port = 1337 # TODO: set as you like
     cidr_blocks = ["0.0.0.0/0"]
   }
-
   egress {
     from_port   = 0
     to_port     = 0
@@ -47,6 +45,7 @@ resource "aws_security_group" "tfgoat-cluster" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
 
 resource "aws_security_group_rule" "tfgoat-cluster-ingress-workstation-https" {
   cidr_blocks       = ["0.0.0.0/0"]


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

Your security group defines all ingress ports are open, exposing resources in the VPC to unwanted attacks. If it is intentional, you can help your colleagues by leaving a comment that says it is intentionally done so.

